### PR TITLE
[TASK] Use stable dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "psr-4": {
         }
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "4.0.0-dev"


### PR DESCRIPTION
We don't need minimum-stability: dev as the phpList * dependencies
already explicitly are marked as unstable.

This will make the composer updates much faster.