### PR TITLE
[BUGFIX] Fix the instructions for composer create-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ will be stored (or symlinked to).
 ## Installation
 
 1. Download and install [composer](https://getcomposer.org/download/).
-2. Run `composer create-project phplist/base-distribution your-project`
+2. Run `composer create-project -s dev phplist/base-distribution your-project`
    (use any name you like for the `your-project` directory).
 3. Switch to the `your-project` directory.
 4. If you would like to not have the web front end or the REST API, edit the


### PR DESCRIPTION
As this packacge does not have a stable release yet, the user needs to
add "-s dev" to the composer create-project command.

Fixes #16