### PR TITLE
[BUGFIX] Make the Composer scripts independent of the working directory

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -103,14 +103,18 @@ We will only merge pull requests that follow the project's coding style.
 
 Please check your code with the provided PHP_CodeSniffer standard:
 
-    vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/ Tests/
+    vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/ Classes/ Tests/
+
+Please also check the code structure using PHPMD:
+
+    vendor/bin/phpmd Classes/ text vendor/phplist/phplist4-core/Configuration/PHPMD/rules.xml
 
 And also please run the static code analysis:
 
-    vendor/bin/phpstan analyse -l 5 Tests/
+    vendor/bin/phpstan analyse -l 5 Classes/ Tests/
 
 You can also run all code style checks using one long line from a bash shell:
-    find Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l && vendor/bin/phpstan analyse -l 5 Tests/ && vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/ Tests/
+    find Classes/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l && vendor/bin/phpstan analyse -l 5 Classes/ Tests/ && vendor/bin/phpmd Classes/ text vendor/phplist/phplist4-core/Configuration/PHPMD/rules.xml && vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/ Classes/ Tests/
 
 This will execute all tests except for the unit tests and the integration
 tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - >
     echo;
     echo "Linting all PHP files";
-    find Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l;
+    find Classes/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l;
 
   - >
     echo;
@@ -31,9 +31,14 @@ script:
   - >
     echo;
     echo "Running the static analysis";
-    vendor/bin/phpstan analyse -l 5 Tests/;
+    vendor/bin/phpstan analyse -l 5 Classes/ Tests/;
+
+  - >
+    echo;
+    echo "Running PHPMD";
+    vendor/bin/phpmd Classes/ text vendor/phplist/phplist4-core/Configuration/PHPMD/rules.xml;
 
   - >
     echo;
     echo "Running PHP_CodeSniffer";
-    vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/ Tests/;
+    vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/ Classes/ Tests/;

--- a/Classes/Composer/ScriptHandler.php
+++ b/Classes/Composer/ScriptHandler.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\BaseDistribution\Composer;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * This class provides Composer-related functionality for setting up and managing phpList modules.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+class ScriptHandler
+{
+    /**
+     * @return string absolute application root directory including the trailing slash
+     */
+    private static function getApplicationRoot(): string
+    {
+        return dirname(__DIR__, 2) . '/';
+    }
+
+    /**
+     * @return string absolute directory including the trailing slash
+     */
+    private static function getCoreDirectory(): string
+    {
+        return self::getApplicationRoot() . 'vendor/phplist/phplist4-core/';
+    }
+
+    /**
+     * Creates the "bin/" directory and its contents.
+     *
+     * @return void
+     *
+     * @throws IOException
+     */
+    public static function createBinaries()
+    {
+        $fileSystem = new Filesystem();
+        $fileSystem->mirror(self::getCoreDirectory() . 'bin/', self::getApplicationRoot() . 'bin/');
+    }
+
+    /**
+     * Creates the "web/" directory and its contents.
+     *
+     * @return void
+     *
+     * @throws IOException
+     */
+    public static function createPublicWebDirectory()
+    {
+        $fileSystem = new Filesystem();
+        $fileSystem->mirror(self::getCoreDirectory() . 'web/', self::getApplicationRoot() . 'web/');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,15 @@
     "require-dev": {
         "phpunit/phpunit": "^6.2.2",
         "squizlabs/php_codesniffer": "^3.0.1",
-        "phpstan/phpstan": "^0.7.0"
+        "phpstan/phpstan": "^0.7.0",
+        "phpmd/phpmd": "^2.6.0"
     },
     "suggest": {
         "phplist/web-frontend": "4.0.x-dev"
     },
     "autoload": {
         "psr-4": {
+            "PhpList\\BaseDistribution\\": "Classes/"
         }
     },
     "autoload-dev": {
@@ -49,10 +51,10 @@
     },
     "scripts": {
         "binaries": [
-            "cp -rf --preserve vendor/phplist/phplist4-core/bin/ ."
+            "PhpList\\BaseDistribution\\Composer\\ScriptHandler::createBinaries"
         ],
         "document-root": [
-            "cp -rf vendor/phplist/phplist4-core/web/ ."
+            "PhpList\\BaseDistribution\\Composer\\ScriptHandler::createPublicWebDirectory"
         ],
         "post-install-cmd": [
             "@binaries",


### PR DESCRIPTION
This allows the scripts to work correctly e.g., when running
composer create-project.

Fixes #23