### PR TITLE
[BUGFIX] Fix copying of files after create-project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
             "@binaries",
             "@document-root"
         ],
-        "post-root-package-install": [
+        "post-create-project-cmd": [
             "@binaries",
             "@document-root"
         ]


### PR DESCRIPTION
The files need to be copied after the create-project event
(which also installs the depencies), not already after installing
the root package, as we copy the binaries and the web root from a
dependency.