### PR TITLE
[FEATURE] Clear the Symfony caches on a composer install/update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,9 @@
         ],
         "update-configuration": [
             "PhpList\\PhpList4\\Composer\\ScriptHandler::createBundleConfiguration",
-            "PhpList\\PhpList4\\Composer\\ScriptHandler::createRoutesConfiguration"
+            "PhpList\\PhpList4\\Composer\\ScriptHandler::createRoutesConfiguration",
+            "PhpList\\PhpList4\\Composer\\ScriptHandler::clearAllCaches",
+            "PhpList\\PhpList4\\Composer\\ScriptHandler::warmProductionCache"
         ],
         "post-install-cmd": [
             "@create-directories",
@@ -78,7 +80,7 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         },
-        "symfony-app-dir": "Classes",
+        "symfony-app-dir": "bin",
         "symfony-bin-dir": "bin",
         "symfony-var-dir": "var",
         "symfony-web-dir": "web",


### PR DESCRIPTION
Also warm the production cache.

In addition, fix the configuration for the Symfony application directory
in the composer.json. The directory has to be different than in
the rest-api package as long as this package does not provide any
own bundles.