### PR TITLE
[CLEANUP] Remove module definition from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,10 +84,6 @@
         "symfony-bin-dir": "bin",
         "symfony-var-dir": "var",
         "symfony-web-dir": "web",
-        "symfony-tests-dir": "Tests",
-        "phplist/phplist4-core": {
-            "bundles": [],
-            "routes": {}
-        }
+        "symfony-tests-dir": "Tests"
     }
 }


### PR DESCRIPTION
The base-distribution package is no phpList module and hence should not
have a module definition.