### PR TITLE
[BUGFIX] Do not warm the production caches on composer install/update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,7 @@
             "PhpList\\PhpList4\\Composer\\ScriptHandler::createBundleConfiguration",
             "PhpList\\PhpList4\\Composer\\ScriptHandler::createRoutesConfiguration",
             "PhpList\\PhpList4\\Composer\\ScriptHandler::createParametersConfiguration",
-            "PhpList\\PhpList4\\Composer\\ScriptHandler::clearAllCaches",
-            "PhpList\\PhpList4\\Composer\\ScriptHandler::warmProductionCache"
+            "PhpList\\PhpList4\\Composer\\ScriptHandler::clearAllCaches"
         ],
         "post-install-cmd": [
             "@create-directories",


### PR DESCRIPTION
This fixes composer create-project, and it also is necessary for automatic
TGZ packaging (where the package should not contain any cache data).