### PR TITLE
[TASK] Configure a PHP version for packaging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,11 @@
             "PhpList\\BaseDistribution\\Tests\\": "Tests/"
         }
     },
+    "config": {
+        "platform": {
+            "php": "7.0.8"
+        }
+    },
     "scripts": {
         "list-modules": [
             "PhpList\\PhpList4\\Composer\\ScriptHandler::listModules"


### PR DESCRIPTION
This change to the composer.json makes sure that dependencies are installed
that work with PHP 7.0 and do not require PHP 7.1 or 7.2 even if the
package is created on a system with PHP 7.1 or 7.2, making the packge
work on PHP 7.0.

PHP 7.0.8 is used because some dependencies require PHP >= 7.0.8.