### PR TITLE
[BUGFIX] Fix Composer-related build failure with PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "roave/security-advisories": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5.0",
+        "phpunit/phpunit": "^6.5.6",
+        "phpunit/phpunit-mock-objects": "^5.0.6",
         "guzzlehttp/guzzle": "^6.3.0",
         "squizlabs/php_codesniffer": "^3.2.0",
         "phpstan/phpstan": "^0.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b03c5c8f4705c6c3aa575c8a6655c733",
+    "content-hash": "63ded5d61fc07e5a72d017f3d41a2824",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1465,12 +1465,12 @@
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpList/phplist4-core.git",
+                "url": "https://github.com/phpList/core.git",
                 "reference": "4392e901d95b91664bf34b702480d92bbc21325c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpList/phplist4-core/zipball/4392e901d95b91664bf34b702480d92bbc21325c",
+                "url": "https://api.github.com/repos/phpList/core/zipball/4392e901d95b91664bf34b702480d92bbc21325c",
                 "reference": "4392e901d95b91664bf34b702480d92bbc21325c",
                 "shasum": ""
             },


### PR DESCRIPTION
Composer tries to install doctrine/instantiator 1.1.0 on PHP 7.0,
but this version requires PHP ^7.1. This seems to be a bug in Composer,
and requiring the latest PHP-7.0-compatible version of
phpunit/phpunit-mock-objects works around this issue.